### PR TITLE
Addressing CVE-2017-5645 and CVE-2020-9488 by upgrading log4j2 version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -41,7 +41,7 @@
         <spring.version>3.2.17.RELEASE</spring.version>
         <jackson.version>2.10.0</jackson.version>
         <slf4j.version>1.7.21</slf4j.version>
-        <log4j2.version>2.7</log4j2.version>
+        <log4j2.version>2.13.3</log4j2.version>
         <mockito.version>2.2.9</mockito.version>
     </properties>
 


### PR DESCRIPTION
This PR addresses the following two identified vulnerabilities:

CVE-2017-5645 - Moderate severity
CVE-2020-9488 - Moderate severity